### PR TITLE
Replace SEAQ_SUPPRESS_WARNINGS with SEAQ_LOG_LEVEL for better log control

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Supported environment variables:
 - `OLLAMA_HOST`
 - `JINA_API_KEY`
 - `FIRECRAWL_API_KEY`
-- `SEAQ_SUPPRESS_WARNINGS`
+- `SEAQ_LOG_LEVEL` (default: `info`)
 
 ## Usage
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const version = "0.9.0"
+const version = "0.9.1"
 
 type rootOptions struct {
 	configFile  flag.FilePath

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -1,0 +1,268 @@
+package env
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type EnvSuite struct {
+	suite.Suite
+	originalValues map[string]string
+}
+
+func TestEnvSuite(t *testing.T) {
+	suite.Run(t, &EnvSuite{})
+}
+
+var supportedEnvs = [13]string{
+	OPENAI_API_KEY,
+	ANTHROPIC_API_KEY,
+	GEMINI_API_KEY,
+	YOUTUBE_API_KEY,
+	CHROMA_URL,
+	X_AUTH_TOKEN,
+	X_CSRF_TOKEN,
+	UDEMY_ACCESS_TOKEN,
+	OLLAMA_HOST,
+	JINA_API_KEY,
+	FIRECRAWL_API_KEY,
+	SEAQ_SUPPRESS_WARNINGS,
+	SEAQ_LOG_LEVEL,
+}
+
+func (s *EnvSuite) SetupTest() {
+	s.originalValues = make(map[string]string)
+	for _, key := range supportedEnvs {
+		if val, err := Get(key); err == nil {
+			s.originalValues[key] = val
+		}
+		s.originalValues[key] = ""
+	}
+}
+
+func (s *EnvSuite) TearDownTest() {
+	for key, val := range s.originalValues {
+		if val == "" {
+			os.Unsetenv(key)
+		} else {
+			os.Setenv(key, val)
+		}
+	}
+}
+
+func (s *EnvSuite) Test_LogLevel() {
+	testCases := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		want     slog.Level
+	}{
+		{
+			name:     "debug",
+			envValue: "debug",
+			setEnv:   true,
+			want:     slog.LevelDebug,
+		},
+		{
+			name:     "info",
+			envValue: "info",
+			setEnv:   true,
+			want:     slog.LevelInfo,
+		},
+		{
+			name:     "warn",
+			envValue: "warn",
+			setEnv:   true,
+			want:     slog.LevelWarn,
+		},
+		{
+			name:     "error",
+			envValue: "error",
+			setEnv:   true,
+			want:     slog.LevelError,
+		},
+		{
+			name:     "upperCase",
+			envValue: "DEBUG",
+			setEnv:   true,
+			want:     slog.LevelDebug,
+		},
+		{
+			name:     "mixedCase",
+			envValue: "DeBUG",
+			setEnv:   true,
+			want:     slog.LevelDebug,
+		},
+		{
+			name:     "whitespace",
+			envValue: "  debug  ",
+			setEnv:   true,
+			want:     slog.LevelDebug,
+		},
+		{
+			name:     "invalid",
+			envValue: "invalid",
+			setEnv:   true,
+			want:     slog.LevelInfo,
+		},
+		{
+			name:     "emptyValue",
+			envValue: "",
+			setEnv:   true,
+			want:     slog.LevelInfo,
+		},
+		{
+			name:   "unsetEnv",
+			setEnv: false,
+			want:   slog.LevelInfo,
+		},
+	}
+
+	r := s.Require()
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			if tc.setEnv {
+				os.Setenv(SEAQ_LOG_LEVEL, tc.envValue)
+			} else {
+				os.Unsetenv(SEAQ_LOG_LEVEL)
+			}
+
+			// Test
+			got := LogLevel()
+			r.Equal(tc.want, got)
+		})
+	}
+}
+
+func (s *EnvSuite) Test_LogLevel_BackwardCompatibility() {
+	r := s.Require()
+
+	// Ensure SEAQ_LOG_LEVEL is unset so we hit the backward compatibility path
+	os.Unsetenv(SEAQ_LOG_LEVEL)
+
+	// Set SEAQ_SUPPRESS_WARNINGS to trigger backward compatibility
+	os.Setenv(SEAQ_SUPPRESS_WARNINGS, "true")
+
+	got := LogLevel()
+	r.Equal(slog.LevelError, got)
+}
+
+func (s *EnvSuite) Test_SuppressWarnings() {
+	testCases := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		want     bool
+	}{
+		{
+			name:     "true",
+			envValue: "true",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "1",
+			envValue: "1",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "yes",
+			envValue: "yes",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "y",
+			envValue: "y",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "on",
+			envValue: "on",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "upperCase",
+			envValue: "TRUE",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "mixedCase",
+			envValue: "YeS",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "whitespace",
+			envValue: "  true  ",
+			setEnv:   true,
+			want:     true,
+		},
+		{
+			name:     "false",
+			envValue: "false",
+			setEnv:   true,
+			want:     false,
+		},
+		{
+			name:     "0",
+			envValue: "0",
+			setEnv:   true,
+			want:     false,
+		},
+		{
+			name:     "invalid",
+			envValue: "invalid",
+			setEnv:   true,
+			want:     false,
+		},
+		{
+			name:     "empty",
+			envValue: "",
+			setEnv:   true,
+			want:     false,
+		},
+		{
+			name:   "unset",
+			setEnv: false,
+			want:   false,
+		},
+	}
+
+	r := s.Require()
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			if tc.setEnv {
+				os.Setenv(SEAQ_SUPPRESS_WARNINGS, tc.envValue)
+			} else {
+				os.Unsetenv(SEAQ_SUPPRESS_WARNINGS)
+			}
+
+			got := SuppressWarnings()
+			r.Equal(tc.want, got)
+		})
+	}
+}
+
+func (s *EnvSuite) Test_OllamaHost() {
+	r := s.Require()
+
+	// Test with env var set
+	os.Setenv(OLLAMA_HOST, "http://custom-host:8080")
+	got := OllamaHost()
+	r.Equal("http://custom-host:8080", got)
+
+	// Test with env var unset (should return default)
+	os.Unsetenv(OLLAMA_HOST)
+	got = OllamaHost()
+	r.Equal("http://localhost:11434", got)
+}

--- a/pkg/llm/registry.go
+++ b/pkg/llm/registry.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/nt54hamnghi/seaq/pkg/env"
 	"github.com/nt54hamnghi/seaq/pkg/util/log"
 	"github.com/nt54hamnghi/seaq/pkg/util/pool"
 	"github.com/nt54hamnghi/seaq/pkg/util/set"
@@ -100,12 +99,11 @@ func initRegistry() {
 		var err error
 
 		ctx := context.Background()
-		suppressWarnings := env.SuppressWarnings()
 
 		// Get all providers and their connections
 		listers := []ModelLister{ollamaLister}
 		connMap, err = GetConnections()
-		if err != nil && !suppressWarnings {
+		if err != nil {
 			// failure to load connections is not a fatal error
 			log.Warn("failed to load connections", "error", err)
 		}
@@ -123,13 +121,13 @@ func initRegistry() {
 		for i := 0; i < len(outputs); i++ {
 			provider := listers[i].GetProvider()
 			output := outputs[i]
-			if output.Err != nil && !suppressWarnings {
+			if output.Err != nil {
 				// failure to list models is not a fatal error
 				log.Warn("failed to list models", "provider", provider, "error", output.Err)
 				continue
 			}
 			err := defaultRegistry.Register(provider, output.Output)
-			if err != nil && !suppressWarnings {
+			if err != nil {
 				// failure to register models is not a fatal error
 				log.Warn("failed to register models", "provider", provider, "error", err)
 			}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -4,9 +4,12 @@ import (
 	"log/slog"
 	"os"
 	"time"
+
+	"github.com/nt54hamnghi/seaq/pkg/env"
 )
 
 var DefaultLogger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+	Level: env.LogLevel(),
 	// nolint: revive
 	ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 		if a.Key == slog.TimeKey {


### PR DESCRIPTION
Summary

Replaces `SEAQ_SUPPRESS_WARNINGS` environment variable with `SEAQ_LOG_LEVEL`  that supports granular log level control (`debug`, `info`, `warn`, `error`).

Changes

- Added `SEAQ_LOG_LEVEL` environment variable with support for debug/info/warn/error levels
- Maintained backward compatibility: `SEAQ_SUPPRESS_WARNINGS=true` maps to `SEAQ_LOG_LEVEL=error`
- Simplified log handling in `pkg/llm/registry.go` by removing manual warning suppression checks
- Updated documentation to reflect the new environment variable

Breaking Changes

- None:  `SEAQ_SUPPRESS_WARNINGS` is deprecated but still works for backward compatibility.
