### PR TITLE
feat: Switch YouTube metadata output to JSON format

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const version = "0.9.3"
+const version = "0.10.0"
 
 type rootOptions struct {
 	configFile  flag.FilePath

--- a/pkg/loader/youtube/metadata.go
+++ b/pkg/loader/youtube/metadata.go
@@ -2,6 +2,7 @@ package youtube
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -24,8 +25,13 @@ func getMetadataAsDocument(ctx context.Context, vid videoID) (schema.Document, e
 		return schema.Document{}, err
 	}
 
+	content, err := json.MarshalIndent(snippet, "", "\t")
+	if err != nil {
+		return schema.Document{}, err
+	}
+
 	return schema.Document{
-		PageContent: snippet.String(),
+		PageContent: string(content),
 		Metadata: map[string]interface{}{
 			"videoId": vid,
 			"type":    "metadata",
@@ -78,6 +84,7 @@ Description:
 `, s.Title, s.ChannelTitle, s.Description)
 }
 
+// API docs: https://developers.google.com/youtube/v3/docs/videos/list
 func buildSnippetRequestURL(vid videoID) (string, error) {
 	apiKey, err := env.YoutubeAPIKey()
 	if err != nil {


### PR DESCRIPTION
Changes YouTube metadata from custom string format to structured JSON output for better data processing.

## Changes:

- Use `json.MarshalIndent()` instead of `snippet.String()`
- Version bump to 0.10.0 

## Why this change?

The previous custom string format made it difficult to parse and process YouTube metadata.