### PR TITLE
Add --env support for connection API key configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE-specific files
-/.vscode
 /.cursor
+/.vscode
+/.zed
 .cursorrules
 
 # Temporary files and directories

--- a/cmd/connection/create.go
+++ b/cmd/connection/create.go
@@ -13,6 +13,7 @@ import (
 type createOptions struct {
 	baseURL    flag.URL
 	configFile flag.FilePath
+	envKey     string
 }
 
 func newCreateCmd() *cobra.Command {
@@ -28,7 +29,7 @@ func newCreateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			provider := args[0]
 
-			conn := llm.NewConnection(provider, opts.baseURL.String())
+			conn := llm.NewConnection(provider, opts.baseURL.String(), opts.envKey)
 			if err := config.AddConnection(conn); err != nil {
 				return fmt.Errorf("add connection: %w", err)
 			}
@@ -45,6 +46,7 @@ func newCreateCmd() *cobra.Command {
 	if err := cmd.MarkFlagRequired("url"); err != nil {
 		os.Exit(1)
 	}
+	flags.StringVar(&opts.envKey, "env", "", "Environment variable name for API key")
 	config.AddConfigFlag(cmd, &opts.configFile)
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const version = "0.10.1"
+const version = "0.10.2"
 
 type rootOptions struct {
 	configFile  flag.FilePath

--- a/justfile
+++ b/justfile
@@ -12,10 +12,16 @@ alias w := watch
 
 # run dev binary in ./dev/main.go
 [group('dev')]
-dev:
-    @go run ./dev/main.go
+dev *args:
+    @go run ./dev/main.go {{ args }}
 
 alias d := dev
+
+[group('dev')]
+run *args:
+    @go run ./main.go {{ args }}
+
+alias r := run
 
 # run all tests
 [group('test')]

--- a/pkg/llm/connection.go
+++ b/pkg/llm/connection.go
@@ -28,16 +28,20 @@ func IsIdent(s string) bool {
 type Connection struct {
 	Provider string `mapstructure:"provider" yaml:"provider"`
 	BaseURL  string `mapstructure:"base_url" yaml:"base_url"`
+	EnvKey   string `mapstructure:"env_key" yaml:"env_key"`
 }
 
-func NewConnection(provider string, baseURL string) Connection {
-	return Connection{Provider: provider, BaseURL: baseURL}
+func NewConnection(provider string, baseURL string, envKey string) Connection {
+	if envKey == "" {
+		envKey = strings.ToUpper(provider) + "_API_KEY"
+	}
+	return Connection{provider, baseURL, envKey}
 }
 
 // GetEnvKey returns the environment variable name that stores the API key
 // for the connection. The format is <PROVIDER>_API_KEY.
 func (c Connection) GetEnvKey() string {
-	return strings.ToUpper(c.Provider) + "_API_KEY"
+	return c.EnvKey
 }
 
 // GetProvider implements the ModelLister interface

--- a/pkg/llm/connection_test.go
+++ b/pkg/llm/connection_test.go
@@ -1,0 +1,48 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConnection(t *testing.T) {
+	testCases := []struct {
+		name     string
+		provider string
+		baseURL  string
+		envKey   string
+		want     Connection
+	}{
+		{
+			name:     "default env key if empty",
+			provider: "openai",
+			baseURL:  "https://api.openai.com/v1",
+			envKey:   "",
+			want: Connection{
+				Provider: "openai",
+				BaseURL:  "https://api.openai.com/v1",
+				EnvKey:   "OPENAI_API_KEY",
+			},
+		},
+		{
+			name:     "use provided env key",
+			provider: "groq",
+			baseURL:  "https://api.groq.com/openai/v1",
+			envKey:   "GROQ_SECRET",
+			want: Connection{
+				Provider: "groq",
+				BaseURL:  "https://api.groq.com/openai/v1",
+				EnvKey:   "GROQ_SECRET",
+			},
+		},
+	}
+
+	r := require.New(t)
+	for _, tt := range testCases {
+		t.Run(tt.name, func(*testing.T) {
+			got := NewConnection(tt.provider, tt.baseURL, tt.envKey)
+			r.Equal(tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
This fixes #13

## Summary
- add `--env` flag to `seaq connection create` to explicitly set the API key environment variable
- extend `llm.Connection` with persisted `EnvKey` (`yaml`/`mapstructure` support)
- update `NewConnection` to accept an optional env key and default to `<PROVIDER>_API_KEY` when omitted
- make `GetEnvKey()` return the stored value
- add unit tests for default and custom env key behavior in `pkg/llm/connection_test.go`

## Additional changes in this branch
- bump CLI version to `0.10.2` in `cmd/root.go`
- add `/.zed` to `.gitignore`
- update `justfile` with arg passthrough for `dev` and add `run` recipe alias

## Testing
- `go test ./pkg/llm/...`