### PR TITLE
Clarify required name args in connection create/remove help

### DIFF
--- a/cmd/connection/create.go
+++ b/cmd/connection/create.go
@@ -20,7 +20,7 @@ func newCreateCmd() *cobra.Command {
 	var opts createOptions
 
 	cmd := &cobra.Command{
-		Use:          "create",
+		Use:          "create [name]",
 		Short:        "Create a new connection",
 		Aliases:      []string{"add"},
 		Args:         createArgs,

--- a/cmd/connection/remove.go
+++ b/cmd/connection/remove.go
@@ -16,7 +16,7 @@ func newRemoveCmd() *cobra.Command {
 	var opts removeOptions
 
 	cmd := &cobra.Command{
-		Use:          "remove",
+		Use:          "remove [name]...",
 		Short:        "Remove a connection",
 		Aliases:      []string{"rm"},
 		Args:         cobra.MinimumNArgs(1),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const version = "0.10.2"
+const version = "0.10.3"
 
 type rootOptions struct {
 	configFile  flag.FilePath


### PR DESCRIPTION
## Summary
- update `seaq connection create` usage to `create [name]`
- update `seaq connection remove` usage to `remove [name]...`
- make required positional arguments explicit in command help output

Fixes #14