### PR TITLE
Refactor LLM connections to ConnectionSet

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,16 @@
+[
+  {
+    "label": "Run main.go",
+    "adapter": "Delve",
+    "request": "launch",
+    "mode": "debug",
+    "program": ".",
+    "cwd": "/home/hamnghi/projects/seaq",
+    "args": ["connection", "list"],
+    "buildFlags": [],
+    "env": {},
+  },
+] // Project-local debug tasks
+//
+// For more documentation on how to configure debug tasks,
+// see: https://zed.dev/docs/debugger

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,8 +41,9 @@
 ## Testing Guidelines
 - Tests live alongside code in `*_test.go` files.
 - Use `go test ./cmd/... ./pkg/...` (see `just test`).
-- Prefer table-driven tests and clear case names.
-- Prefer `testify` for assertions in parameterized tests.
+- Use table-driven tests and clear case names.
+- Use `testify` for assertions in parameterized tests.
+- Use `testify/suite` for setup & teardown behaviors.
 - Cover edge cases and error paths; test plan should be explicit for complex features.
 
 ## Commit & Pull Request Guidelines

--- a/cmd/connection/list.go
+++ b/cmd/connection/list.go
@@ -35,7 +35,7 @@ func newListCmd() *cobra.Command {
 			const format = "%s\t%s\t%s\n"
 			fmt.Fprintf(w, format, "PROVIDER", "BASE URL", "ENV KEY")
 			for _, conn := range conns {
-				fmt.Fprintf(w, format, conn.Provider, conn.BaseURL, conn.GetEnvKey())
+				fmt.Fprintf(w, format, conn.Provider, conn.BaseURL, conn.EnvKey)
 			}
 
 			return nil

--- a/pkg/config/connection.go
+++ b/pkg/config/connection.go
@@ -13,41 +13,41 @@ import (
 var ErrUnexpectedType = errors.New("unexpected type of connections")
 
 func AddConnection(conn llm.Connection) error {
-	conns, err := llm.GetConnections()
+	cs, err := llm.GetConnectionSet()
 	if err != nil {
 		return err
 	}
 
-	if _, ok := conns[conn.Provider]; ok {
+	if cs.Has(conn.Provider) {
 		return fmt.Errorf("connection %q already exists", conn.Provider)
 	}
 
-	viper.Set("connections", append(conns.AsSlice(), conn))
+	viper.Set("connections", append(cs.AsSlice(), conn))
 	return viper.WriteConfig()
 }
 
 func RemoveConnection(providers ...string) error {
-	conns, err := llm.GetConnections()
+	cs, err := llm.GetConnectionSet()
 	if err != nil {
 		return err
 	}
 
 	for _, p := range providers {
-		if _, ok := conns[p]; !ok {
+		if !cs.Has(p) {
 			return fmt.Errorf("connection %q not found", p)
 		}
-		delete(conns, p)
+		cs.Delete(p)
 		fmt.Println(p)
 	}
 
-	viper.Set("connections", conns.AsSlice())
+	viper.Set("connections", cs.AsSlice())
 	return viper.WriteConfig()
 }
 
 func ListConnections() ([]llm.Connection, error) {
-	conns, err := llm.GetConnections()
+	cs, err := llm.GetConnectionSet()
 	if err != nil {
 		return nil, err
 	}
-	return conns.AsSlice(), nil
+	return cs.AsSlice(), nil
 }

--- a/pkg/llm/connection.go
+++ b/pkg/llm/connection.go
@@ -1,11 +1,8 @@
-// TESTME:
-
 package llm
 
 import (
 	"context"
 	"fmt"
-	"maps"
 	"net/http"
 	"regexp"
 	"slices"
@@ -38,12 +35,6 @@ func NewConnection(provider string, baseURL string, envKey string) Connection {
 	return Connection{provider, baseURL, envKey}
 }
 
-// GetEnvKey returns the environment variable name that stores the API key
-// for the connection. The format is <PROVIDER>_API_KEY.
-func (c Connection) GetEnvKey() string {
-	return c.EnvKey
-}
-
 // GetProvider implements the ModelLister interface
 // and returns the provider name
 func (c Connection) GetProvider() string {
@@ -53,12 +44,12 @@ func (c Connection) GetProvider() string {
 // List implements the ModelLister interface
 // and returns a slice of available model IDs from the provider.
 func (c Connection) List(ctx context.Context) ([]string, error) {
-	secret, err := env.Get(c.GetEnvKey())
+	secret, err := env.Get(c.EnvKey)
 	if err != nil {
 		return nil, err
 	}
 
-	headers := http.Header{"Authorization": []string{fmt.Sprintf("Bearer %s", secret)}}
+	headers := http.Header{"Authorization": []string{"Bearer " + secret}}
 	res, err := reqx.GetAs[listModelsResponse](ctx, c.BaseURL+"/models", headers)
 	if err != nil {
 		return nil, fmt.Errorf("fetch models: %w", err)
@@ -81,29 +72,47 @@ type listModelsResponse struct {
 	} `json:"data"`
 }
 
-// ConnectionMap is a map of provider name to Connection.
-// It enables O(1) lookup over a slice when provider access is common.
-// The tradeoff is extra upfront work to build the map and duplicated provider
-// names as both map keys and Connection fields.
-type ConnectionMap map[string]Connection
-
-// GetConnections retrieves the LLM provider connections in the config file
-// and constructs a provider-to-Connection map.
-func GetConnections() (ConnectionMap, error) {
-	connections := []Connection{}
-	if err := viper.UnmarshalKey("connections", &connections); err != nil {
-		return ConnectionMap{}, err
-	}
-
-	connMap := make(ConnectionMap)
-	for _, conn := range connections {
-		connMap[conn.Provider] = conn
-	}
-
-	return connMap, nil
+type ConnectionSet struct {
+	connections []Connection
+	index       map[string]*Connection
 }
 
-// AsSlice returns a slice of all connections in the map.
-func (cm ConnectionMap) AsSlice() []Connection {
-	return slices.Collect(maps.Values(cm))
+func GetConnectionSet() (ConnectionSet, error) {
+	connections := []Connection{}
+	if err := viper.UnmarshalKey("connections", &connections); err != nil {
+		return ConnectionSet{}, err
+	}
+
+	index := make(map[string]*Connection)
+	for i := range connections {
+		c := connections[i]
+		index[c.Provider] = &c
+	}
+
+	return ConnectionSet{
+		connections,
+		index,
+	}, nil
+}
+
+func (cs ConnectionSet) AsSlice() []Connection {
+	return cs.connections
+}
+
+func (cs ConnectionSet) Has(provider string) bool {
+	_, ok := cs.index[provider]
+	return ok
+}
+
+func (cs ConnectionSet) Get(provider string) (Connection, bool) {
+	c, ok := cs.index[provider]
+	if !ok || c == nil {
+		return Connection{}, false
+	}
+	return *c, true
+}
+
+func (cs *ConnectionSet) Delete(provider string) {
+	cs.connections = slices.DeleteFunc(cs.connections, func(c Connection) bool { return c.Provider == provider })
+	delete(cs.index, provider)
 }

--- a/pkg/llm/connection_test.go
+++ b/pkg/llm/connection_test.go
@@ -1,9 +1,13 @@
 package llm
 
 import (
+	"maps"
+	"slices"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestNewConnection(t *testing.T) {
@@ -43,6 +47,142 @@ func TestNewConnection(t *testing.T) {
 		t.Run(tt.name, func(*testing.T) {
 			got := NewConnection(tt.provider, tt.baseURL, tt.envKey)
 			r.Equal(tt.want, got)
+		})
+	}
+}
+
+type ConnectionSetTestSuite struct {
+	suite.Suite
+}
+
+func TestConnectionSetTestSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionSetTestSuite))
+}
+
+func (s *ConnectionSetTestSuite) SetupTest() {
+	viper.Reset()
+	viper.Set("connections",
+		[]map[string]string{
+			{
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+				"env_key":  "OPENAI_API_KEY",
+			},
+			{
+				"provider": "groq",
+				"base_url": "https://api.groq.com/openai/v1",
+				"env_key":  "GROQ_API_KEY",
+			},
+		},
+	)
+}
+
+func (s *ConnectionSetTestSuite) TearDownTest() {
+	viper.Reset()
+}
+
+func (s *ConnectionSetTestSuite) TestGetConnectionSet_UnmarshalError() {
+	viper.Set("connections", "invalid")
+
+	_, err := GetConnectionSet()
+	s.Error(err)
+}
+
+func (s *ConnectionSetTestSuite) TestGetConnectionSet() {
+	r := s.Require()
+
+	cs, err := GetConnectionSet()
+	r.NoError(err)
+
+	r.Equal([]Connection{
+		{
+			Provider: "openai",
+			BaseURL:  "https://api.openai.com/v1",
+			EnvKey:   "OPENAI_API_KEY",
+		},
+		{
+			Provider: "groq",
+			BaseURL:  "https://api.groq.com/openai/v1",
+			EnvKey:   "GROQ_API_KEY",
+		},
+	}, cs.AsSlice())
+	r.True(cs.Has("openai"))
+	r.False(cs.Has("anthropic"))
+}
+
+func (s *ConnectionSetTestSuite) TestConnectionSet_Get() {
+	r := s.Require()
+
+	cs, err := GetConnectionSet()
+	r.NoError(err)
+
+	testCases := []struct {
+		name     string
+		provider string
+		wantConn Connection
+		wantOk   bool
+	}{
+		{
+			name:     "existing provider",
+			provider: "groq",
+			wantConn: Connection{
+				Provider: "groq",
+				BaseURL:  "https://api.groq.com/openai/v1",
+				EnvKey:   "GROQ_API_KEY",
+			},
+			wantOk: true,
+		},
+		{
+			name:     "missing provider",
+			provider: "anthropic",
+			wantConn: Connection{},
+			wantOk:   false,
+		},
+	}
+
+	for _, tt := range testCases {
+		s.Run(tt.name, func() {
+			conn, ok := cs.Get(tt.provider)
+			r.Equal(tt.wantOk, ok)
+			r.Equal(tt.wantConn, conn)
+		})
+	}
+}
+
+func (s *ConnectionSetTestSuite) TestConnectionSet_Delete() {
+	r := s.Require()
+
+	cs, err := GetConnectionSet()
+	r.NoError(err)
+
+	testCases := []struct {
+		name              string
+		toDelete          string
+		wantProvidersLeft []string
+	}{
+		{
+			name:              "existing provider",
+			toDelete:          "openai",
+			wantProvidersLeft: []string{"groq"},
+		},
+		{
+			name:              "non-existent provider",
+			toDelete:          "non-existent",
+			wantProvidersLeft: []string{"groq"},
+		},
+	}
+
+	for _, tt := range testCases {
+		s.Run(tt.name, func() {
+			cs.Delete(tt.toDelete)
+
+			ps := make([]string, 0, len(cs.connections))
+			for _, conn := range cs.connections {
+				ps = append(ps, conn.Provider)
+			}
+
+			r.Equal(tt.wantProvidersLeft, ps)
+			r.Equal(tt.wantProvidersLeft, slices.Collect(maps.Keys(cs.index)))
 		})
 	}
 }

--- a/pkg/llm/llm.go
+++ b/pkg/llm/llm.go
@@ -120,13 +120,17 @@ func New(name string) (llms.Model, error) {
 			ollama.WithServerURL(env.OllamaHost()),
 		)
 	default:
-		// TODO: check if provider is in connMap
-		conn, ok := connMap[provider]
+		connections, err := GetConnectionSet()
+		if err != nil {
+			return nil, err
+		}
+
+		conn, ok := connections.Get(provider)
 		if !ok {
 			return nil, fmt.Errorf("unexpected error: provider %s not found", provider)
 		}
 
-		apiKey, err := env.Get(conn.GetEnvKey())
+		apiKey, err := env.Get(conn.EnvKey)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/llm/registry.go
+++ b/pkg/llm/registry.go
@@ -98,10 +98,7 @@ var defaultRegistry = ModelRegistry{
 	},
 }
 
-var (
-	initOnce sync.Once
-	connMap  ConnectionMap
-)
+var initOnce sync.Once
 
 // initRegistry loads the connections and their corresponding model lists
 // and registers the models in the default registry.
@@ -113,11 +110,11 @@ func initRegistry() {
 
 		// Get all providers and their connections
 		listers := []ModelLister{ollamaLister}
-		connMap, err = GetConnections()
+		connections, err := GetConnectionSet()
 		if err != nil {
 			log.Warn("failed to load connections", "error", err)
 		}
-		for _, conn := range connMap {
+		for _, conn := range connections.AsSlice() {
 			listers = append(listers, conn)
 		}
 


### PR DESCRIPTION
## Summary
- Replace `ConnectionMap`/`GetConnections` with `ConnectionSet`/`GetConnectionSet`.
- Add `ConnectionSet` methods for common operations: `AsSlice`, `Has`, `Get`, and `Delete`.
- Update call sites in config/llm/registry flows to use the new API.
- Add and refactor tests in `pkg/llm/connection_test.go`, including suite-based setup/teardown for viper-backed tests.

## Why
- Centralize connection collection behavior behind an explicit type.
- Improve test coverage for connection loading and mutation behavior.

## Testing
- `go test ./pkg/llm/...`